### PR TITLE
feat: add kube definitions for chain specific boost bots

### DIFF
--- a/.deploy/base/arb_boost_bot.yaml
+++ b/.deploy/base/arb_boost_bot.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: arb-boost-bot
+  labels:
+    app: arb-boost-bot
+spec:
+  schedule: "*/20 * * * *"
+  startingDeadlineSeconds: 180
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: arb-boost-bot
+          containers:
+          - name: arb-boost-bot
+            image: IMAGE_NAME
+            imagePullPolicy: IfNotPresent
+            command: ["python", "-m", "scripts.rewards.boost_arbitrum"]
+            env:
+              - name: LOG_LEVEL
+                value: 'info'
+              - name: TEST
+                value: 'True'
+              - name: KUBE
+                value: 'True'
+          restartPolicy: OnFailure

--- a/.deploy/base/eth_boost_bot.yaml
+++ b/.deploy/base/eth_boost_bot.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: eth-boost-bot
+  labels:
+    app: eth-boost-bot
+spec:
+  schedule: "*/20 * * * *"
+  startingDeadlineSeconds: 180
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: eth-boost-bot
+          containers:
+          - name: eth-boost-bot
+            image: IMAGE_NAME
+            imagePullPolicy: IfNotPresent
+            command: ["python", "-m", "scripts.rewards.boost_eth"]
+            env:
+              - name: LOG_LEVEL
+                value: 'info'
+              - name: TEST
+                value: 'True'
+              - name: KUBE
+                value: 'True'
+          restartPolicy: OnFailure

--- a/.deploy/base/kustomization.yaml
+++ b/.deploy/base/kustomization.yaml
@@ -3,7 +3,10 @@ kind: Kustomization
 resources:
   - approve_arb_cycle_bot.yaml
   - approve_poly_cycle_bot.yaml
+  - arb_boost_bot.yaml
   - boost_bot.yaml
+  - eth_boost_bot.yaml
+  - poly_boost_bot.yaml
   - propose_arb_cycle_bot.yaml
   - propose_eth_cycle_bot.yaml
   - propose_poly_cycle_bot.yaml

--- a/.deploy/base/poly_boost_bot.yaml
+++ b/.deploy/base/poly_boost_bot.yaml
@@ -1,0 +1,28 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: poly-boost-bot
+  labels:
+    app: poly-boost-bot
+spec:
+  schedule: "*/20 * * * *"
+  startingDeadlineSeconds: 180
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          serviceAccountName: poly-boost-bot
+          containers:
+          - name: poly-boost-bot
+            image: IMAGE_NAME
+            imagePullPolicy: IfNotPresent
+            command: ["python", "-m", "scripts.rewards.boost_polygon"]
+            env:
+              - name: LOG_LEVEL
+                value: 'info'
+              - name: TEST
+                value: 'True'
+              - name: KUBE
+                value: 'True'
+          restartPolicy: OnFailure

--- a/.deploy/base/service.yaml
+++ b/.deploy/base/service.yaml
@@ -82,3 +82,45 @@ spec:
     - name: http
       port: 9000
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  name: eth-boost-bot
+  labels:
+    app: eth-boost-bot
+    service: eth-boost-bot
+spec:
+  selector:
+    app: eth-boost-bot
+  ports:
+    - name: http
+      port: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: arb-boost-bot
+  labels:
+    app: arb-boost-bot
+    service: arb-boost-bot
+spec:
+  selector:
+    app: arb-boost-bot
+  ports:
+    - name: http
+      port: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: poly-boost-bot
+  labels:
+    app: poly-boost-bot
+    service: poly-boost-bot
+spec:
+  selector:
+    app: poly-boost-bot
+  ports:
+    - name: http
+      port: 9000
+---

--- a/.deploy/base/service_account.yaml
+++ b/.deploy/base/service_account.yaml
@@ -40,3 +40,24 @@ metadata:
   annotations:
     eks.amazonaws.com/role-arn: arn:aws:iam::342684350154:role/propose-eth-cycle-bot
 ---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: eth-boost-bot
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::342684350154:role/eth-boost-bot
+---
+  apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: arb-boost-bot
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::342684350154:role/arb-boost-bot
+---
+  apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: poly-boost-bot
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::342684350154:role/poly-boost-bot
+---


### PR DESCRIPTION
Note: need to keep propose_boost script so that old bot is still running

Do not merge until aws infra created, confirmed by comment here.