### PR TITLE
Type hinting for functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+.idea/*
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/rewards/calc_rewards.py
+++ b/rewards/calc_rewards.py
@@ -21,24 +21,12 @@ from rewards.aws.boost import add_multipliers
 from rewards.aws.boost import download_boosts
 from rewards.aws.trees import upload_tree
 from rewards.classes.CycleLogger import cycle_logger
-from rewards.classes.RewardsList import RewardsList
 from rewards.classes.RewardsManager import RewardsManager
-from rewards.classes.RewardsManager import RewardsManager
-from rewards.classes.TreeManager import TreeManager
 from rewards.classes.Schedule import Schedule
 from rewards.classes.TreeManager import TreeManager
-from rewards.rewards_utils import combine_rewards, process_cumulative_rewards
 from rewards.rewards_checker import verify_rewards
 from rewards.rewards_utils import combine_rewards
-from rewards.aws.boost import add_multipliers, download_boosts
-from rewards.classes.CycleLogger import cycle_logger
-from helpers.web3_utils import make_contract
-from helpers.constants import (
-    DISABLED_VAULTS,
-    EMISSIONS_CONTRACTS,
-)
-from helpers.enums import Network, BotType
-from helpers.discord import get_discord_url, send_message_to_discord
+from rewards.rewards_utils import process_cumulative_rewards
 from subgraph.queries.setts import list_setts
 
 console = Console()
@@ -103,38 +91,14 @@ def fetch_setts(chain: str) -> List[str]:
     return list(filter(lambda x: x not in DISABLED_VAULTS, setts))
 
 
-def process_cumulative_rewards(current, new: RewardsList) -> RewardsList:
-    """Combine past rewards with new rewards
-
-    :param current: current rewards
-    :param new: new rewards
-    """
-    result = RewardsList(new.cycle)
-
-    # Add new rewards
-    for user, claims in new.claims.items():
-        for token, claim in claims.items():
-            result.increase_user_rewards(user, token, claim)
-
-    # Add existing rewards
-    for user, user_data in current["claims"].items():
-        for i in range(len(user_data["tokens"])):
-            token = user_data["tokens"][i]
-            amount = user_data["cumulativeAmounts"][i]
-            result.increase_user_rewards(user, token, int(amount))
-
-    # result.printState()
-    return result
-
-
 def propose_root(
     chain: str,
     start: int,
     end: int,
-    past_rewards,
+    past_rewards: Dict,
     tree_manager: TreeManager,
     save=False,
-):
+) -> None:
     """
     Propose a root on a chain
 
@@ -142,6 +106,8 @@ def propose_root(
     :param start: start block for rewards
     :param end: end block for rewards
     :param save: flag to save rewards file locally, defaults to False
+    :param past_rewards: past rewards merkle tree
+    :param tree_manager: TreeManager object
     :type save: bool, optional
     """
     current_merkle_data = tree_manager.fetch_current_merkle_data()

--- a/rewards/calc_rewards.py
+++ b/rewards/calc_rewards.py
@@ -131,13 +131,15 @@ def propose_root(
 
 
 def approve_root(
-    chain: str, start: int, end: int, current_rewards, tree_manager: TreeManager
+    chain: str, start: int, end: int, current_rewards: Dict, tree_manager: TreeManager
 ):
     """Approve latest root on a chain
 
     :param chain: chain to approve root
     :param start: start block for rewards
     :param end: end block for rewards
+    :param current_rewards: past rewards merkle tree
+    :param tree_manager: TreeManager object
     """
     cycle_logger.set_start_block(start)
     cycle_logger.set_end_block(end)
@@ -192,7 +194,7 @@ def approve_root(
 
 
 def generate_rewards_in_range(
-    chain: str, start: int, end: int, save: bool, past_tree, tree_manager: TreeManager
+    chain: str, start: int, end: int, save: bool, past_tree: Dict, tree_manager: TreeManager
 ):
     """Generate chain rewards for a chain within two blocks
 
@@ -200,6 +202,8 @@ def generate_rewards_in_range(
     :param start: start block for rewards
     :param end: end block for rewards
     :param save: flag to save file locally
+    :param past_tree: past rewards merkle tree
+    :param tree_manager: TreeManager object
     """
     all_schedules, setts = fetch_all_schedules(chain, fetch_setts(chain))
 

--- a/rewards/calc_rewards.py
+++ b/rewards/calc_rewards.py
@@ -1,9 +1,35 @@
+import json
+from typing import Dict
+from typing import List
+from typing import Tuple
+
+from eth_utils.hexadecimal import encode_hex
+from hexbytes import HexBytes
+from rich.console import Console
+from web3 import Web3
+
+from config.rewards_config import rewards_config
+from config.singletons import env_config
+from helpers.constants import DISABLED_VAULTS
+from helpers.constants import EMISSIONS_CONTRACTS
+from helpers.discord import get_discord_url
+from helpers.discord import send_message_to_discord
+from helpers.enums import BotType
+from helpers.enums import Network
+from helpers.web3_utils import make_contract
+from rewards.aws.boost import add_multipliers
+from rewards.aws.boost import download_boosts
 from rewards.aws.trees import upload_tree
+from rewards.classes.CycleLogger import cycle_logger
+from rewards.classes.RewardsList import RewardsList
+from rewards.classes.RewardsManager import RewardsManager
 from rewards.classes.RewardsManager import RewardsManager
 from rewards.classes.TreeManager import TreeManager
 from rewards.classes.Schedule import Schedule
+from rewards.classes.TreeManager import TreeManager
 from rewards.rewards_utils import combine_rewards, process_cumulative_rewards
 from rewards.rewards_checker import verify_rewards
+from rewards.rewards_utils import combine_rewards
 from rewards.aws.boost import add_multipliers, download_boosts
 from rewards.classes.CycleLogger import cycle_logger
 from helpers.web3_utils import make_contract
@@ -14,14 +40,6 @@ from helpers.constants import (
 from helpers.enums import Network, BotType
 from helpers.discord import get_discord_url, send_message_to_discord
 from subgraph.queries.setts import list_setts
-from rich.console import Console
-from config.singletons import env_config
-from config.rewards_config import rewards_config
-from eth_utils.hexadecimal import encode_hex
-from hexbytes import HexBytes
-from typing import List, Dict
-from web3 import Web3
-import json
 
 console = Console()
 
@@ -39,14 +57,14 @@ def parse_schedules(schedules) -> Dict[str, List[Schedule]]:
     """
     schedules_by_token = {}
     console.log("Fetching schedules...")
-    for s in schedules:
+    for schedule in schedules:
         schedule = Schedule(
-            Web3.toChecksumAddress(s[0]),
-            Web3.toChecksumAddress(s[1]),
-            s[2],
-            s[3],
-            s[4],
-            s[5],
+            Web3.toChecksumAddress(schedule[0]),
+            Web3.toChecksumAddress(schedule[1]),
+            schedule[2],
+            schedule[3],
+            schedule[4],
+            schedule[5],
         )
         if schedule.token not in schedules_by_token:
             schedules_by_token[schedule.token] = []
@@ -54,7 +72,9 @@ def parse_schedules(schedules) -> Dict[str, List[Schedule]]:
     return schedules_by_token
 
 
-def fetch_all_schedules(chain: str, setts: List[str]):
+def fetch_all_schedules(
+    chain: str, setts: List[str]
+) -> Tuple[Dict[str, Dict[str, List[Schedule]]], List[str]]:
     """
     Fetch all schedules on a particular chain
     :param chain: chain to fetch from
@@ -81,6 +101,30 @@ def fetch_setts(chain: str) -> List[str]:
     """
     setts = list_setts(chain)
     return list(filter(lambda x: x not in DISABLED_VAULTS, setts))
+
+
+def process_cumulative_rewards(current, new: RewardsList) -> RewardsList:
+    """Combine past rewards with new rewards
+
+    :param current: current rewards
+    :param new: new rewards
+    """
+    result = RewardsList(new.cycle)
+
+    # Add new rewards
+    for user, claims in new.claims.items():
+        for token, claim in claims.items():
+            result.increase_user_rewards(user, token, claim)
+
+    # Add existing rewards
+    for user, user_data in current["claims"].items():
+        for i in range(len(user_data["tokens"])):
+            token = user_data["tokens"][i]
+            amount = user_data["cumulativeAmounts"][i]
+            result.increase_user_rewards(user, token, int(amount))
+
+    # result.printState()
+    return result
 
 
 def propose_root(

--- a/rewards/classes/RewardsManager.py
+++ b/rewards/classes/RewardsManager.py
@@ -244,7 +244,7 @@ class RewardsManager:
 
         return total_to_distribute
 
-    def boost_sett(self, sett: str, snapshot: Snapshot):
+    def boost_sett(self, sett: str, snapshot: Snapshot) -> Snapshot:
         if snapshot.type == BalanceType.NonNative:
             pre_boost = {}
             for user, balance in snapshot:

--- a/rewards/classes/RewardsManager.py
+++ b/rewards/classes/RewardsManager.py
@@ -146,8 +146,7 @@ class RewardsManager:
         return combine_rewards([rewards, *extra_rewards], self.cycle)
 
     def distribute_rewards_to_snapshot(
-        self, amount: float, snapshot: Snapshot, token: str
-    ):
+            self, amount: float, snapshot: Snapshot, token: str) -> RewardsList:
         """
         Distribute a certain amount of rewards to a snapshot of users
         """

--- a/rewards/classes/RewardsManager.py
+++ b/rewards/classes/RewardsManager.py
@@ -175,7 +175,7 @@ class RewardsManager:
 
         return combine_rewards(all_rewards, self.cycle + 1)
 
-    def get_sett_multipliers(self):
+    def get_sett_multipliers(self) -> Dict[str, Dict[str, float]]:
         sett_multipliers = {}
         for sett, user_apy_boosts in self.apy_boosts.items():
             sett_multipliers[sett] = {

--- a/rewards/classes/RewardsManager.py
+++ b/rewards/classes/RewardsManager.py
@@ -292,7 +292,7 @@ class RewardsManager:
             )
         return combine_rewards(all_dist_rewards, self.cycle)
 
-    def calc_sushi_distributions(self) -> Tuple[RewardsList, float]:
+    def calc_sushi_distributions(self) -> RewardsList:
         sushi_events = fetch_sushi_harvest_events(self.start, self.end)
         all_from_events = 0
         all_sushi_rewards = []
@@ -305,7 +305,7 @@ class RewardsManager:
         assert abs(all_from_events - all_from_rewards) < 1e9
         return combine_rewards(all_sushi_rewards, self.cycle)
 
-    def calc_sushi_distribution(self, strategy: str, events):
+    def calc_sushi_distribution(self, strategy: str, events: List[Dict]) -> Tuple[RewardsList, int]:
         sett = self.get_sett_from_strategy(strategy)
         total_from_rewards = 0
         all_sushi_rewards = []

--- a/rewards/explorer.py
+++ b/rewards/explorer.py
@@ -1,7 +1,10 @@
-import requests
-from config.singletons import env_config
-from typing import Dict
 import time
+from typing import Dict
+from typing import Optional
+
+import requests
+
+from config.singletons import env_config
 from helpers.enums import Network
 
 urls = {
@@ -11,7 +14,7 @@ urls = {
 }
 
 
-def fetch_block_by_timestamp(chain: str, timestamp: int):
+def fetch_block_by_timestamp(chain: str, timestamp: int) -> Optional[Dict]:
     chain_url = f"https://api.{urls[chain]}"
     url = (
         f"api?module=block&action=getblocknobytime&timestamp={timestamp}&closest=before"

--- a/rewards/rewards_checker.py
+++ b/rewards/rewards_checker.py
@@ -1,17 +1,18 @@
+import json
+from typing import Optional
+from typing import Tuple
+
+from rich.console import Console
+from tabulate import tabulate
+
+from helpers.constants import TOKENS_TO_CHECK
+from helpers.digg_utils import digg_utils
+from helpers.discord import get_discord_url
+from helpers.discord import send_code_block_to_discord
+from helpers.discord import send_error_to_discord
+from helpers.enums import BotType
 from rewards.classes.TreeManager import TreeManager
 from rewards.snapshot.claims_snapshot import claims_snapshot
-from tabulate import tabulate
-from rich.console import Console
-from config.singletons import env_config
-from helpers.constants import SANITY_TOKEN_AMOUNT, TOKENS_TO_CHECK
-from helpers.discord import (
-    get_discord_url,
-    send_code_block_to_discord,
-    send_error_to_discord,
-)
-from helpers.digg_utils import digg_utils
-from helpers.enums import BotType
-import json
 
 console = Console()
 
@@ -41,7 +42,8 @@ def val(amount, decimals=18):
     return f"{amount / 10 ** decimals:,.18f}"
 
 
-def token_diff_table(name, before, after, decimals=18):
+def token_diff_table(
+        name: str, before: float, after: float, decimals: Optional[int] = 18) -> Tuple[float, str]:
     diff = after - before
     console.print(f"Diff for {name} \n")
     table = []

--- a/rewards/rewards_utils.py
+++ b/rewards/rewards_utils.py
@@ -35,7 +35,7 @@ def keccak(value: str):
     return Web3.toHex(Web3.keccak(text=value))
 
 
-def combine_rewards(rewards_list: List[RewardsList], cycle):
+def combine_rewards(rewards_list: List[RewardsList], cycle) -> RewardsList:
     combined_rewards = RewardsList(cycle)
     for rewards in rewards_list:
         for user, claims in rewards.claims.items():

--- a/rewards/tree_utils.py
+++ b/rewards/tree_utils.py
@@ -1,3 +1,6 @@
+from typing import Dict
+from typing import Tuple
+
 from subgraph.queries.setts import last_synced_block
 from rewards.classes.TreeManager import TreeManager
 from rich.console import Console
@@ -6,10 +9,10 @@ from helpers.enums import Network
 console = Console()
 
 
-def get_last_proposed_cycle(chain: str, tree_manager: TreeManager):
+def get_last_proposed_cycle(chain: str, tree_manager: TreeManager) -> Tuple[Dict, int, int]:
     if not tree_manager.has_pending_root():
         console.log("[bold yellow]===== No pending root, exiting =====[/bold yellow]")
-        return ({}, 0, 0)
+        return {}, 0, 0
 
     console.log("Pending root found.. approving")
 
@@ -26,10 +29,10 @@ def get_last_proposed_cycle(chain: str, tree_manager: TreeManager):
     # assert lastClaimEnd > chain.height - rewards_config.maxStartBlockAge
 
     # Sanity check: Ensure start block is not too close to end block
-    return (current_rewards, last_claim_start, last_claim_end)
+    return current_rewards, last_claim_start, last_claim_end
 
 
-def calc_next_cycle_range(chain: str, tree_manager: TreeManager):
+def calc_next_cycle_range(chain: str, tree_manager: TreeManager) -> Tuple[Dict, int, int]:
     # Fetch the appropriate file
     current_rewards = tree_manager.fetch_current_tree()
 
@@ -45,4 +48,4 @@ def calc_next_cycle_range(chain: str, tree_manager: TreeManager):
     assert start_block < end_block
 
     # Sanity check: Ensure start block is not too close to end block
-    return (current_rewards, start_block, end_block)
+    return current_rewards, start_block, end_block


### PR DESCRIPTION
# #139 <--- 

## **Done:**
- Functions that are covered now with typehints:
```
to_merkle_format
bcvx_claims_snapshot
bcvxcrv_claims_snapshot
distribute_rewards_to_snapshot
get_sett_multipliers
get_user_multipliers
boost_sett
calc_sushi_distribution
convert_to_merkle_tree
propose_root
manage_root
fetch_all_schedules
generate_rewards_in_range
fetch_block_by_timestamp
token_diff_table
combine_rewards
get_last_proposed_cycle
calc_next_cycle_range
```
- Lots of PEP8 improvements in Python
- Sorting out imports

### **What is not done:**
Functions like:
```
fetch_tree
fetch_current_tree
fetch_pending_tree
fetch_current_merkle_data
fetch_pending_merkle_data
```
are pretty sensitive and we don't have enough test coverage on those, making changing types of those quite scary. 
_**What I suggest:**_ come back to typehinting those functions(or even wrapping their output into dataclasses) when we have better test coverage and it's not so scary to change those types