### PR TITLE
Http client to remove boilerplate unwrapping for requests

### DIFF
--- a/badger_api/requests.py
+++ b/badger_api/requests.py
@@ -1,10 +1,10 @@
 import concurrent.futures
 from functools import lru_cache
-from typing import Dict, Optional, Tuple
+from typing import Dict, List, Optional, Tuple, Union
 
 from badger_api.config import get_api_base_path
 from helpers.constants import BOOST_CHAINS
-from helpers.http_session import http
+from helpers.http_client import http_client
 
 badger_api = get_api_base_path()
 
@@ -13,10 +13,7 @@ def fetch_ppfs() -> Optional[Tuple[float, float]]:
     """
     Fetch ppfs for bbadger and bdigg
     """
-    response = http.get(f"{badger_api}/setts")
-    if not response.ok:
-        return
-    setts = response.json()
+    setts = http_client.get(f"{badger_api}/setts")
     if not setts:
         return
     badger = [sett for sett in setts if sett["asset"] == "BADGER"][0]
@@ -32,10 +29,7 @@ def fetch_token_prices() -> Dict[str, float]:
     chains = BOOST_CHAINS
     prices = {}
     for chain in chains:
-        response = http.get(f"{badger_api}/prices?chain={chain}")
-        if not response.ok:
-            continue
-        chain_prices = response.json()
+        chain_prices = http_client.get(f"{badger_api}/prices?chain={chain}")
         if not chain_prices:
             continue
         prices = {**prices, **chain_prices}
@@ -48,10 +42,7 @@ def fetch_claimable(page: int, chain: str) -> Optional[Dict]:
     Fetch claimable data from account data
     :param page: page to fetch data from
     """
-    response = http.get(f"{badger_api}/accounts/allClaimable?page={page}&chain={chain}")
-    if not response.ok:
-        return
-    return response.json()
+    return http_client.get(f"{badger_api}/accounts/allClaimable?page={page}&chain={chain}")
 
 
 def fetch_total_claimable_pages(chain: str) -> Optional[int]:
@@ -83,11 +74,8 @@ def fetch_all_claimable_balances(chain: str) -> Optional[Dict]:
 
 
 @lru_cache
-def fetch_token_names(chain: str):
-    response = http.get(f"{badger_api}/tokens?chain={chain}")
-    if not response.ok:
-        return
-    return response.json()
+def fetch_token_names(chain: str) -> Optional[Union[Dict, List]]:
+    return http_client.get(f"{badger_api}/tokens?chain={chain}")
 
 
 def fetch_token(chain: str, token: str):

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,0 +1,5 @@
+from helpers.http_session import http_client
+
+__all__ = [
+    "http_client",
+]

--- a/helpers/__init__.py
+++ b/helpers/__init__.py
@@ -1,5 +1,0 @@
-from helpers.http_session import http_client
-
-__all__ = [
-    "http_client",
-]

--- a/helpers/http_client.py
+++ b/helpers/http_client.py
@@ -1,0 +1,41 @@
+from typing import Dict, List, Optional, Union
+
+import requests
+from requests import Response
+
+from helpers.http_session import http
+
+
+class HTTPClient:
+    """
+    Wrapper class on top of requests library
+    Serves as unwrapper on each HTTP request to avoid boilerplate request.status_code checking
+
+    All method signatures are matching respective requests.HTTP_method()
+
+    For example, self.get(self, url, **kwargs) is mathching requests.get(self, url, **kwargs)
+    signature
+
+    Implement more HTTP methods as needed
+    """
+    def __init__(self, http_session: requests.Session):
+        self.http = http_session
+        assert type(self.http) == requests.Session
+
+    @staticmethod
+    def _unwrap_response(response_obj: Response) -> Optional[Union[Dict, List]]:
+        if response_obj.ok:
+            return response_obj.json()
+
+    def get(self, url, **kwargs) -> Optional[Union[Dict, List]]:
+        return self._unwrap_response(
+            self.http.get(url, **kwargs)
+        )
+
+    def post(self, url, data=None, json=None, **kwargs) -> Optional[Union[Dict, List]]:
+        return self._unwrap_response(
+            self.http.post(url, data=data, json=json, **kwargs)
+        )
+
+
+http_client = HTTPClient(http)

--- a/helpers/http_client.py
+++ b/helpers/http_client.py
@@ -13,7 +13,7 @@ class HTTPClient:
 
     All method signatures are matching respective requests.HTTP_method()
 
-    For example, self.get(self, url, **kwargs) is mathching requests.get(self, url, **kwargs)
+    For example, self.get(self, url, **kwargs) is matching requests.get(self, url, **kwargs)
     signature
 
     Implement more HTTP methods as needed

--- a/helpers/http_session.py
+++ b/helpers/http_session.py
@@ -1,6 +1,8 @@
+from typing import Dict, List, Optional, Union
+
 import requests
 from decouple import config
-from requests import HTTPError
+from requests import HTTPError, Response
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -35,3 +37,37 @@ http = requests.Session()
 http.mount("https://", adapter)
 http.mount("http://", adapter)
 http.hooks["response"] = [status_hook]
+
+
+class HTTPClient:
+    """
+    Wrapper class on top of requests library
+    Serves as unwrapper on each HTTP request to avoid boilerplate request.status_code checking
+
+    All method signatures are matching respective requests.HTTP_method()
+
+    For example, self.get(self, url, **kwargs) is mathching requests.get(self, url, **kwargs)
+    signature
+
+    Implement more HTTP methods as needed
+    """
+    def __init__(self, http_session: requests.Session):
+        self.http = http_session
+
+    @staticmethod
+    def _unwrap_response(response_obj: Response) -> Optional[Union[Dict, List]]:
+        if response_obj.ok:
+            return response_obj.json()
+
+    def get(self, url, **kwargs) -> Optional[Union[Dict, List]]:
+        return self._unwrap_response(
+            self.http.get(url, **kwargs)
+        )
+
+    def post(self, url, data=None, json=None, **kwargs) -> Optional[Union[Dict, List]]:
+        return self._unwrap_response(
+            self.http.post(url, data=data, json=json, **kwargs)
+        )
+
+
+http_client = HTTPClient(http)

--- a/helpers/http_session.py
+++ b/helpers/http_session.py
@@ -1,8 +1,6 @@
-from typing import Dict, List, Optional, Union
-
 import requests
 from decouple import config
-from requests import HTTPError, Response
+from requests import HTTPError
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
@@ -37,37 +35,3 @@ http = requests.Session()
 http.mount("https://", adapter)
 http.mount("http://", adapter)
 http.hooks["response"] = [status_hook]
-
-
-class HTTPClient:
-    """
-    Wrapper class on top of requests library
-    Serves as unwrapper on each HTTP request to avoid boilerplate request.status_code checking
-
-    All method signatures are matching respective requests.HTTP_method()
-
-    For example, self.get(self, url, **kwargs) is mathching requests.get(self, url, **kwargs)
-    signature
-
-    Implement more HTTP methods as needed
-    """
-    def __init__(self, http_session: requests.Session):
-        self.http = http_session
-
-    @staticmethod
-    def _unwrap_response(response_obj: Response) -> Optional[Union[Dict, List]]:
-        if response_obj.ok:
-            return response_obj.json()
-
-    def get(self, url, **kwargs) -> Optional[Union[Dict, List]]:
-        return self._unwrap_response(
-            self.http.get(url, **kwargs)
-        )
-
-    def post(self, url, data=None, json=None, **kwargs) -> Optional[Union[Dict, List]]:
-        return self._unwrap_response(
-            self.http.post(url, data=data, json=json, **kwargs)
-        )
-
-
-http_client = HTTPClient(http)

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,0 +1,8 @@
+{
+  "coverage": {},
+  "highlights": {
+    "branches": {},
+    "statements": {}
+  },
+  "sha1": {}
+}

--- a/reports/coverage.json
+++ b/reports/coverage.json
@@ -1,8 +1,0 @@
-{
-  "coverage": {},
-  "highlights": {
-    "branches": {},
-    "statements": {}
-  },
-  "sha1": {}
-}

--- a/rewards/explorer.py
+++ b/rewards/explorer.py
@@ -1,9 +1,9 @@
 import time
-from typing import Dict, Optional
+from typing import Dict, List, Optional, Union
 
 from config.singletons import env_config
 from helpers.enums import Network
-from helpers.http_session import http
+from helpers.http_client import http_client
 
 urls = {
     Network.Ethereum: "etherscan.io",
@@ -12,16 +12,13 @@ urls = {
 }
 
 
-def fetch_block_by_timestamp(chain: str, timestamp: int) -> Optional[Dict]:
+def fetch_block_by_timestamp(chain: str, timestamp: int) -> Optional[Union[Dict, List]]:
     chain_url = f"https://api.{urls[chain]}"
     url = (
         f"api?module=block&action=getblocknobytime&timestamp={timestamp}&closest=before"
     )
     api_key = f"apikey={env_config.get_explorer_api_key(chain)}"
-    response = http.get(f"{chain_url}/{url}&{api_key}")
-    if not response.ok:
-        return
-    return response.json()
+    return http_client.get(f"{chain_url}/{url}&{api_key}")
 
 
 def get_block_by_timestamp(chain: str, timestamp: int) -> int:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,3 +5,7 @@ import pytest
 """
 pytest looks for the conftest modules on test collection to gather custom hooks and fixtures, and in order to import the custom objects from them, pytest adds the parent directory of the conftest.py to the sys.path (in this case the repo directory).
 """
+
+@pytest.fixture
+def mock_discord(mocker):
+    return mocker.patch("helpers.http_session.send_message_to_discord")

--- a/tests/test_http_client.py
+++ b/tests/test_http_client.py
@@ -1,0 +1,38 @@
+import pytest
+import requests
+import responses
+
+from helpers.http_client import HTTPClient, http_client
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    'http_method', ["get", "post"]
+)
+def test_http_client__returns_none_on_err(mock_discord, http_method):
+    url = "https://api.etherscan.io/api?module=block&action=" \
+          "getblocknobytime&timestamp=123&closest=before&apikey="
+    responses.add(
+        http_method.upper(), url,
+        json={"some": "payload"}, status=404
+    )
+    assert getattr(http_client, http_method)(url) is None
+
+
+@responses.activate
+@pytest.mark.parametrize(
+    'http_method', ["get", "post"]
+)
+def test_http_client__returns_valid_response(mock_discord, http_method):
+    url = "https://api.etherscan.io/api?module=block&action=" \
+          "getblocknobytime&timestamp=123&closest=before&apikey="
+    responses.add(
+        http_method.upper(), url,
+        json={"some": "payload"}, status=200
+    )
+    assert getattr(http_client, http_method)(url) == {"some": "payload"}
+
+
+def test_invalid_injected_http():
+    with pytest.raises(AssertionError):
+        HTTPClient(requests.Request)  # noqa

--- a/tests/test_http_requests_functions.py
+++ b/tests/test_http_requests_functions.py
@@ -14,11 +14,6 @@ from helpers.constants import BOOST_CHAINS
 from rewards.explorer import fetch_block_by_timestamp
 
 
-@pytest.fixture
-def mock_discord(mocker):
-    return mocker.patch("helpers.http_session.send_message_to_discord")
-
-
 @responses.activate
 def test_fetch_block_by_timestamp_handled(mock_discord):
     responses.add(


### PR DESCRIPTION
**Problem:**
Wrap http.get function to remove boiler plate code

**Done:**
- Add `HTTPClient` object that acts as `requests` library proxy by doing `_unwrap_response` on each HTTP method
- Use `http_client` now in all internal requests instead of `http` session object
- Remove boilerplate code
- Move `mock_discord` to `conftest.py` to be accessible for all tests
- Tests

Fixes #308 
