### PR TITLE
Add pytest-cov to github test action

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit =
+    abis/*
+    deploy/*
+    images/*
+    rewards_tests/*
+
+[report]
+show_missing = True

--- a/.github/workflows/test_run.yaml
+++ b/.github/workflows/test_run.yaml
@@ -1,4 +1,11 @@
-on: ['pull_request']
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - development
+      - main
+  pull_request:
 
 name: main workflow
 
@@ -49,4 +56,9 @@ jobs:
               run: pip install -r requirements.txt && pip install -r requirements-dev.txt
 
             - name: Run Tests
-              run: brownie test
+              run: brownie test --cov-report=xml --cov=.
+
+            - uses: codecov/codecov-action@v2
+              with:
+                fail_ci_if_error: false
+                token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test_run.yaml
+++ b/.github/workflows/test_run.yaml
@@ -58,7 +58,7 @@ jobs:
             - name: Run Tests
               run: brownie test --cov-report=xml --cov=.
 
-            - uses: codecov/codecov-action@v2
+            - uses: codecov/codecov-action@v1
               with:
                 fail_ci_if_error: false
                 token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 ![Badger Logo](./images/badger-logo.png)
 
+### Test coverage:
+[![codecov](https://codecov.io/gh/Badger-Finance/badger-rewards/branch/main/graph/badge.svg?token=0JIZAA720B)](https://codecov.io/gh/Badger-Finance/badger-rewards)
+
 # Badger Rewards
 
 Badger Rewards hosts scripts directly related to the Badger Rewards system, including:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 responses==0.16.0
 pytest-mock==3.6.1
+pytest-cov==3.0.0


### PR DESCRIPTION
Add code corerage tools to badger-rewards repo.

Also:
- Add `pytest-cov` to dev requirements since it's required to run pytest with coverage
- Change CI triggers, now it runs on each PUSH to main and development branches
- Update README with coverage badge

**Note:** Once this PR is merged, we will be able to track coverage here https://app.codecov.io/gh/Badger-Finance/badger-rewards/
But you can already see the coverage for this branch here: https://codecov.io/gh/Badger-Finance/badger-rewards/tree/733d9241196f6028395a4b6e0afe2be704b73a63

Fixes #369 