### PR TITLE
Fix cov badge with proper url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 ![Badger Logo](./images/badger-logo.png)
 
 ### Test coverage:
-[![codecov](https://codecov.io/gh/Badger-Finance/badger-rewards/branch/main/graph/badge.svg?token=0JIZAA720B)](https://codecov.io/gh/Badger-Finance/badger-rewards)
-
+[![codecov](https://codecov.io/gh/Badger-Finance/badger-rewards/branch/development/graph/badge.svg?token=0JIZAA720B)](https://codecov.io/gh/Badger-Finance/badger-rewards)
 # Badger Rewards
 
 Badger Rewards hosts scripts directly related to the Badger Rewards system, including:


### PR DESCRIPTION
<img width="256" alt="Screenshot 2021-11-22 at 19 35 07" src="https://user-images.githubusercontent.com/7059697/142908513-84da1315-b8a9-4086-901b-fc2fde8edf99.png">
