### PR TITLE
chore: increase gql log level to WARNING

### DIFF
--- a/subgraph/subgraph_utils.py
+++ b/subgraph/subgraph_utils.py
@@ -1,7 +1,9 @@
+import logging
 from typing import Optional
 
 from gql import Client
 from gql.transport.requests import RequestsHTTPTransport
+from gql.transport.requests import log as requests_logger
 
 from subgraph.config import subgraph_urls
 
@@ -14,6 +16,7 @@ def subgraph_url(name: str) -> str:
 
 
 def make_gql_client(name: str) -> Optional[Client]:
+    requests_logger.setLevel(logging.WARNING)
     url = subgraph_url(name)
     if not url:
         return


### PR DESCRIPTION
Now GQL log level is warning.

Guide taken from https://gql.readthedocs.io/en/v3.0.0rc0/advanced/logging.html#disabling-logs

Fixes #446 