### PR TITLE
Feat: rpc failback list

### DIFF
--- a/config/env_config.py
+++ b/config/env_config.py
@@ -13,6 +13,8 @@ logging.getLogger("gql.transport.aiohttp").setLevel("WARNING")
 
 
 class EnvConfig:
+    rpc_logger = logging.getLogger("rpc-logger")
+
     def __init__(self):
         environment = config("ENV", "").lower()
         self.test = environment == Environment.Test
@@ -41,19 +43,40 @@ class EnvConfig:
             ),
         }
         # TODO: set polygon back to paid node
-        polygon = Web3(Web3.HTTPProvider("https://polygon-rpc.com/"))
-        polygon.middleware_onion.inject(geth_poa_middleware, layer=0)
+        polygon = [
+            Web3(Web3.HTTPProvider("https://polygon-rpc.com/")),
+            self.make_provider("quiknode/poly-node-url", "NODE_URL"),
+        ]
+        for node in polygon:
+            node.middleware_onion.inject(geth_poa_middleware, layer=0)
 
         self.web3 = {
-            Network.Ethereum: self.make_provider("quiknode/eth-node-url", "NODE_URL"),
-            Network.Arbitrum: Web3(Web3.HTTPProvider("https://arb1.arbitrum.io/rpc")),
+            Network.Ethereum: [
+                self.make_provider("quiknode/eth-node-url", "NODE_URL"),
+            ],
+            Network.Arbitrum: [
+                Web3(Web3.HTTPProvider("https://arb1.arbitrum.io/rpc")),
+                self.make_provider("moralis/arbitrum-node-url", "ARBITRUM_NODE_URL"),
+                self.make_provider("alchemy/arbitrum-node-url", "ARBITRUM_NODE_URL"),
+            ],
             Network.Polygon: polygon,
         }
 
         self.is_valid_config()
 
     def get_web3(self, chain: str = Network.Ethereum) -> Web3:
-        return self.web3[chain]
+        return self.get_healthy_node(chain)  
+    
+    def get_healthy_node(self, chain: Network) -> Web3:
+        for node in self.web3[chain]:
+            try:
+                node.eth.get_block_number()
+                return node
+            except Exception as e:
+                self.rpc_logger.info(f"{node.provider.endpoint_uri} unhealthy")
+                self.rpc_logger.info(e)
+
+        raise Exception(f"No healthy nodes for chain: {chain}")
 
     def get_explorer_api_key(self, chain: str) -> str:
         return self.explorer_api_keys[chain]

--- a/tests/test_utils/test_env_config.py
+++ b/tests/test_utils/test_env_config.py
@@ -9,7 +9,7 @@ os.environ["KUBE"] = "False"
 os.environ["AWS_ACCESS_KEY_ID"] = ""
 os.environ["AWS_SECRET_ACCESS_KEY"] = ""
 
-from config.env_config import EnvConfig
+from config.env_config import EnvConfig, NoHealthyNode
 from helpers.enums import Environment, Network
 
 logger = logging.getLogger("test-env-config")
@@ -36,7 +36,7 @@ def test_get_environment():
         env_config = EnvConfig()
         assert env_config.get_environment() == expected
 
-def test_get_web3(mocker):
+def test_get_web3_happy(mocker):
     env_config = EnvConfig()
     env_config.web3[Network.Polygon] = [
         MagicMock(
@@ -62,3 +62,31 @@ def test_get_web3(mocker):
     ]
     web3 = env_config.get_web3(Network.Polygon)
     assert web3.provider.endpoint_uri == "healthy-rpc.com"
+
+
+def test_get_web3_unhappy(mocker):
+    env_config = EnvConfig()
+    env_config.web3[Network.Polygon] = [
+        MagicMock(
+            eth=MagicMock(
+                get_block_number=MagicMock(
+                    side_effect=Exception
+                )
+            ),
+            provider=MagicMock(
+                endpoint_uri="unhealthy-rpc.com"
+            )
+        ),
+        MagicMock(
+            eth=MagicMock(
+                get_block_number=MagicMock(
+                    side_effect=Exception
+                )
+            ),
+            provider=MagicMock(
+                endpoint_uri="unhealthy-rpc-2.com"
+            )
+        ),
+    ]
+    with pytest.raises(NoHealthyNode):
+        web3 = env_config.get_web3(Network.Polygon)

--- a/tests/test_utils/test_env_config.py
+++ b/tests/test_utils/test_env_config.py
@@ -3,12 +3,14 @@ import os
 
 import pytest
 
+from unittest.mock import MagicMock
+
 os.environ["KUBE"] = "False"
 os.environ["AWS_ACCESS_KEY_ID"] = ""
 os.environ["AWS_SECRET_ACCESS_KEY"] = ""
 
 from config.env_config import EnvConfig
-from helpers.enums import Environment
+from helpers.enums import Environment, Network
 
 logger = logging.getLogger("test-env-config")
 
@@ -33,3 +35,30 @@ def test_get_environment():
         os.environ["ENV"] = val
         env_config = EnvConfig()
         assert env_config.get_environment() == expected
+
+def test_get_web3(mocker):
+    env_config = EnvConfig()
+    env_config.web3[Network.Polygon] = [
+        MagicMock(
+            eth=MagicMock(
+                get_block_number=MagicMock(
+                    side_effect=Exception
+                )
+            ),
+            provider=MagicMock(
+                endpoint_uri="unhealthy-rpc.com"
+            )
+        ),
+        MagicMock(
+            eth=MagicMock(
+                get_block_number=MagicMock(
+                    return_value=1
+                )
+            ),
+            provider=MagicMock(
+                endpoint_uri="healthy-rpc.com"
+            )
+        ),
+    ]
+    web3 = env_config.get_web3(Network.Polygon)
+    assert web3.provider.endpoint_uri == "healthy-rpc.com"


### PR DESCRIPTION
Note: ticket here https://github.com/Badger-Finance/badger-rewards/issues/181 says to send logs to discord. The current set up doesn't provide a good way to pass a bot specific discord url into the function so the reporting would be messy. Now that logs are exposed on cloudwatch I felt it was sufficient to log the output.